### PR TITLE
Fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,27 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>5.1.0</version>
+            <version>5.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.palantir.docker.compose</groupId>
+            <artifactId>docker-compose-junit-jupiter</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.palantir.docker.compose</groupId>
+            <artifactId>docker-compose-rule-junit4</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.palantir.docker.compose</groupId>
+            <artifactId>docker-compose-rule-core</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jcustenborder</groupId>
+            <artifactId>docker-compose-junit-extension</artifactId>
+            <version>0.1.6</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
## Problems solved by this PR

This PR fixes **two mayor problems** I encountered while building this artifact:

- [Maven 3.8^ blocks custom repos by default](https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291) not allowing confluent dependencies to be downloaded.
- [Bintray repos (where some dependencies were stored) are no longer active](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), so original links to dependencies don't work anymore.

## How are those problems solved

- Only by modifying pom.xml file.
- Adding Confluent repo to trusted to repositories.
- Migrating from bintray to maven central repository by pinning plugins and dependencies from bintray to their relatives in central maven repository.

## Related issues

- Fixes #4 
- Fixes issue in original jonahharris repo https://github.com/jonahharris/kafka-connect-rabbitmq/issues/13
- It also allows this artifact to be built from inside a fresh docker image (not settings.xml needed)