### PR TITLE
Make message expiration configurable in the sink connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ Connection TCP establishment timeout in milliseconds. zero for infinite. See `Co
 
 
 The AMQP0-9-1 protocol handshake timeout, in milliseconds. See `ConnectionFactory.setHandshakeTimeout(int) <https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/ConnectionFactory.html#setHandshakeTimeout-int->`_
+##### `rabbitmq.expiration.ms`
+*Importance:* Low
+
+*Type:* Int
+
+*Default Value*: no message expiration
+
+
+The message expiration (TTL) property, in milliseconds. See `AMQP.BasicProperties.Builder.expiration(string) <https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/client/AMQP.BasicProperties.Builder.html#expiration(java.lang.String)>`_
 ##### `rabbitmq.network.recovery.interval.ms`
 *Importance:* Low
 

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkConnectorConfig.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkConnectorConfig.java
@@ -19,7 +19,11 @@ package com.github.themeetgroup.kafka.connect.rabbitmq.sink;
 import java.util.Map;
 
 import com.github.themeetgroup.kafka.connect.rabbitmq.CommonRabbitMQConnectorConfig;
+
+import io.confluent.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigDef;
+
+import org.apache.kafka.common.config.ConfigDef.Validator;
 
 import com.github.jcustenborder.kafka.connect.utils.template.StructTemplate;
 
@@ -36,14 +40,17 @@ public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
   public static final String ROUTING_KEY_CONF = "rabbitmq.routing.key";
   static final String ROUTING_KEY_DOC = "routing key used for publishing the messages.";
 
-
   public static final String HEADER_CONF = "rabbitmq.headers";
   public static final String HEADER_CONF_DOC = "Headers to set for outbounf messages. Set with `headername1`:`headervalue1`,`headername2`:`headervalue2`";
-    //TODO: include other config variables here
+
+  public static final String EXPIRATION_CONF = "rabbitmq.expiration.ms";
+  public static final String EXPIRATION_CONF_DOC = "The expiration message property in milliseconds >= 0 (see https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/client/AMQP.BasicProperties.Builder.html#expiration(java.lang.String)).";
+  //TODO: include other config variables here
 
   public final StructTemplate kafkaTopic;
   public final String exchange;
   public final String routingKey;
+  public final int expiration;
 
   public RabbitMQSinkConnectorConfig(Map<String, String> settings) {
     super(config(), settings);
@@ -52,6 +59,7 @@ public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
     this.kafkaTopic.addTemplate(KAFKA_TOPIC_TEMPLATE, kafkaTopicFormat);
     this.exchange = this.getString(EXCHANGE_CONF);
     this.routingKey = this.getString(ROUTING_KEY_CONF);
+    this.expiration = this.getInt(EXPIRATION_CONF);
   }
 
   public static ConfigDef config() {
@@ -59,9 +67,24 @@ public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
         .define(TOPIC_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TOPIC_DOC)
         .define(EXCHANGE_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, EXCHANGE_DOC)
         .define(ROUTING_KEY_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, ROUTING_KEY_DOC)
-        .define(HEADER_CONF, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.LOW, HEADER_CONF_DOC);
-
-
+        .define(HEADER_CONF, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.LOW, HEADER_CONF_DOC)
+        .define(EXPIRATION_CONF, ConfigDef.Type.INT, -1, EXPIRATION_VALIDATOR, ConfigDef.Importance.LOW,
+            EXPIRATION_CONF_DOC);
   }
 
+  private static final ExpirationValidator EXPIRATION_VALIDATOR = new ExpirationValidator();
+
+  private static class ExpirationValidator implements Validator {
+    @Override
+    public void ensureValid(String name, Object value) {
+      if (value instanceof Integer) {
+        int expiration = (Integer) value;
+        if (expiration < -1) {
+          throw new ConfigException(name, value, "must be >= 0.");
+        }
+      } else {
+        throw new ConfigException(name, value, "must be an integer.");
+      }
+    }
+  }
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkHeaderParser.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkHeaderParser.java
@@ -43,7 +43,7 @@ public class RabbitMQSinkHeaderParser {
 
   }
 
-  static AMQP.BasicProperties parse(final String headerConfig) {
+  static AMQP.BasicProperties.Builder parse(AMQP.BasicProperties.Builder builder, final String headerConfig) {
     final Map<String, Object> headerTemp = DEFAULT_HEADERS.entrySet()
             .stream()
             .map(entry -> new Pair<>(entry.getKey(), entry.getValue().get()))
@@ -55,7 +55,7 @@ public class RabbitMQSinkHeaderParser {
               .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
       headers.forEach((k, v) -> headerTemp.merge(k, v, (o, n) -> n));
     }
-    return new AMQP.BasicProperties.Builder().headers(headerTemp).build();
+    return builder.headers(headerTemp);
   }
 
   private static final class Pair<K, V> extends AbstractMap.SimpleEntry<K, V> {


### PR DESCRIPTION
Using the configuration value rabbitmq.expiration.ms the basic property expiration (message-level time-to-live) can be set for messages published by the sink connector to RabbitMQ.